### PR TITLE
Fix unlikely buffer overflows and avoid parameter name confusion

### DIFF
--- a/Incremental.c
+++ b/Incremental.c
@@ -1030,12 +1030,12 @@ static int array_try_spare(char *devname, int *dfdp, struct dev_policy *pol,
 		int mdfd = open_dev(chosen->sys_name);
 		if (mdfd >= 0) {
 			struct mddev_dev devlist;
-			char devname[20];
+			char chosen_devname[24]; // 2*11 for int (including signs) + colon + null
 			devlist.next = NULL;
 			devlist.used = 0;
 			devlist.writemostly = 0;
-			devlist.devname = devname;
-			sprintf(devname, "%d:%d", major(stb.st_rdev),
+			devlist.devname = chosen_devname;
+			sprintf(chosen_devname, "%d:%d", major(stb.st_rdev),
 				minor(stb.st_rdev));
 			devlist.disposition = 'a';
 			close(dfd);

--- a/Incremental.c
+++ b/Incremental.c
@@ -663,7 +663,7 @@ static void find_reject(int mdfd, struct supertype *st, struct mdinfo *sra,
 			 * without thinking more */
 
 	for (d = sra->devs; d ; d = d->next) {
-		char dn[10];
+		char dn[24]; // 2*11 bytes for ints (including sign) + colon + null byte
 		int dfd;
 		struct mdinfo info;
 		sprintf(dn, "%d:%d", d->disk.major, d->disk.minor);

--- a/mapfile.c
+++ b/mapfile.c
@@ -176,7 +176,7 @@ void map_read(struct map_ent **melp)
 {
 	FILE *f;
 	char buf[8192];
-	char path[200];
+	char path[201];
 	int uuid[4];
 	char devnm[32];
 	char metadata[30];


### PR DESCRIPTION
Came across those when analysing the mdadm source. The two buffer overflows are extremely unlikely to happen, but we might as well make sure they never do. Additionally, the ```devname``` buffer on line 1033 of ```Incremental.c``` shadows a parameter to the function in which it occurs.

Feel free to ignore and close this PR.