### PR TITLE
Detail.c --test fix

### DIFF
--- a/Detail.c
+++ b/Detail.c
@@ -339,7 +339,8 @@ int Detail(char *dev, struct context *c)
 		    (disks[d*2+1].state & (1<<MD_DISK_SYNC))) {
 			avail_disks ++;
 			avail[d] = 1;
-		}
+		} else
+			rv |= !! c->test;
 	}
 
 	if (c->brief) {
@@ -672,9 +673,6 @@ This is pretty boring
 			}
 		}
 		if (disk.state == 0) spares++;
-		if (c->test && d < array.raid_disks
-		    && !(disk.state & (1<<MD_DISK_SYNC)))
-			rv |= 1;
 		dv=map_dev_preferred(disk.major, disk.minor, 0, c->prefer);
 		if (dv != NULL) {
 			if (c->brief)


### PR DESCRIPTION
Fixing issue: https://github.com/neilbrown/mdadm/issues/17:

Degradation in 3.2 to 3.3.4, last working 3.2.6.

mdadm --detail  --test returns 0 on for degraded array, when only the second of two disks is removed, works as expected when the first disk removed.

Expected:
  --test        -t   : exit status 0 if ok, 1 if degrade, 2 if dead, 4 if missing
```
Expected:
mdadm --detail  /dev/md2 --test ; echo $?
/dev/md2:
        Version : 1.2
  Creation Time : Thu Dec 10 11:50:20 2015
     Raid Level : raid1
     Array Size : 780226240 (744.08 GiB 798.95 GB)
  Used Dev Size : 780226240 (744.08 GiB 798.95 GB)
   Raid Devices : 2
  Total Devices : 1
    Persistence : Superblock is persistent

  Intent Bitmap : Internal

    Update Time : Thu Dec 10 11:50:22 2015
          State : active, degraded
 Active Devices : 1
Working Devices : 1
 Failed Devices : 0
  Spare Devices : 0

           Name : A1
           UUID : 333592b4:40d92ae2:9cf82398:b92d466e
         Events : 24

    Number   Major   Minor   RaidDevice State
       0       0        0        0      removed
       1       8       34        1      active sync   /dev/sdc2
1
^^ not a bug

Bug:

mdadm --detail  /dev/md1 --test ; echo $?
/dev/md1:
        Version : 1.2
  Creation Time : Thu Dec 10 11:39:41 2015
     Raid Level : raid1
     Array Size : 780226240 (744.08 GiB 798.95 GB)
  Used Dev Size : 780226240 (744.08 GiB 798.95 GB)
   Raid Devices : 2
  Total Devices : 1
    Persistence : Superblock is persistent

  Intent Bitmap : Internal

    Update Time : Thu Dec 10 11:42:35 2015
          State : active, degraded
 Active Devices : 1
Working Devices : 1
 Failed Devices : 0
  Spare Devices : 0

           Name : A1
           UUID : 6a29c716:b804f9f3:3519867f:32f98380
         Events : 32

    Number   Major   Minor   RaidDevice State
       0       8       18        0      active sync   /dev/sdb2
       2       0        0        2      removed
0
^^^ BUG

```