### PR TITLE
util.c: include poll.h instead of sys/poll.h

### DIFF
--- a/util.c
+++ b/util.c
@@ -24,7 +24,6 @@
 
 #include	"mdadm.h"
 #include	"md_p.h"
-#include	<sys/poll.h>
 #include	<sys/socket.h>
 #include	<sys/utsname.h>
 #include	<sys/wait.h>
@@ -32,6 +31,7 @@
 #include	<sys/resource.h>
 #include	<sys/vfs.h>
 #include	<linux/magic.h>
+#include	<poll.h>
 #include	<ctype.h>
 #include	<dirent.h>
 #include	<signal.h>


### PR DESCRIPTION
This fixes a compile warning when building with musl:

 In file included from util.c:27:0:
 |
 qemux86-64/usr/include/sys/poll.h:1:2:
 error: #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
 [-Werror=cpp]
 |  #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
 |   ^

Signed-off-by: Maxin B. John <maxin.john@intel.com>