### PR TITLE
Some fixes to allow for more than 128 md devices.

### DIFF
--- a/Assemble.c
+++ b/Assemble.c
@@ -599,18 +599,9 @@ static int load_devices(struct devs *devices, char *devmap,
 			int err;
 			fstat(mdfd, &stb2);
 
-			if (strcmp(c->update, "uuid")==0 &&
-			    !ident->uuid_set) {
-				int rfd;
-				if ((rfd = open("/dev/urandom", O_RDONLY)) < 0 ||
-				    read(rfd, ident->uuid, 16) != 16) {
-					*(__u32*)(ident->uuid) = random();
-					*(__u32*)(ident->uuid+1) = random();
-					*(__u32*)(ident->uuid+2) = random();
-					*(__u32*)(ident->uuid+3) = random();
-				}
-				if (rfd >= 0) close(rfd);
-			}
+			if (strcmp(c->update, "uuid") == 0 && !ident->uuid_set)
+				random_uuid((__u8 *)ident->uuid);
+
 			dfd = dev_open(devname,
 				       tmpdev->disposition == 'I'
 				       ? O_RDWR : (O_RDWR|O_EXCL));

--- a/Create.c
+++ b/Create.c
@@ -774,9 +774,9 @@ int Create(struct supertype *st, char *mddev,
 				st->ss->name);
 			goto abort_locked;
 		}
-		if (!st->ss->add_internal_bitmap(st, &s->bitmap_chunk,
-						 c->delay, s->write_behind,
-						 bitmapsize, 1, major_num)) {
+		if (st->ss->add_internal_bitmap(st, &s->bitmap_chunk,
+						c->delay, s->write_behind,
+						bitmapsize, 1, major_num)) {
 			pr_err("Given bitmap chunk size not supported.\n");
 			goto abort_locked;
 		}

--- a/Create.c
+++ b/Create.c
@@ -114,8 +114,13 @@ int Create(struct supertype *st, char *mddev,
 	unsigned long long newsize;
 
 	int major_num = BITMAP_MAJOR_HI;
-	if (s->bitmap_file && strcmp(s->bitmap_file, "clustered") == 0)
+	if (s->bitmap_file && strcmp(s->bitmap_file, "clustered") == 0) {
 		major_num = BITMAP_MAJOR_CLUSTERED;
+		if (c->nodes <= 1) {
+			pr_err("At least 2 nodes are needed for cluster-md\n");
+			return 1;
+		}
+	}
 
 	memset(&info, 0, sizeof(info));
 	if (s->level == UnSet && st && st->ss->default_geometry)

--- a/Detail.c
+++ b/Detail.c
@@ -130,7 +130,7 @@ int Detail(char *dev, struct context *c)
 		/* This is a subarray of some container.
 		 * We want the name of the container, and the member
 		 */
-		int devid = devnm2devid(st->container_devnm);
+		dev_t devid = devnm2devid(st->container_devnm);
 		int cfd, err;
 
 		member = subarray;
@@ -577,7 +577,7 @@ This is pretty boring
 				char path[200];
 				char vbuf[1024];
 				int nlen = strlen(sra->sys_name);
-				int devid;
+				dev_t devid;
 				if (de->d_name[0] == '.')
 					continue;
 				sprintf(path, "/sys/block/%s/md/metadata_version",

--- a/Detail.c
+++ b/Detail.c
@@ -323,7 +323,8 @@ int Detail(char *dev, struct context *c)
 		if (disk.major == 0 && disk.minor == 0)
 			continue;
 		if (disk.raid_disk >= 0 && disk.raid_disk < array.raid_disks
-		    && disks[disk.raid_disk*2].state == (1<<MD_DISK_REMOVED))
+		    && disks[disk.raid_disk*2].state == (1<<MD_DISK_REMOVED)
+		    && ((disk.state & (1<<MD_DISK_JOURNAL)) == 0))
 			disks[disk.raid_disk*2] = disk;
 		else if (disk.raid_disk >= 0 && disk.raid_disk < array.raid_disks
 			 && disks[disk.raid_disk*2+1].state == (1<<MD_DISK_REMOVED)

--- a/Grow.c
+++ b/Grow.c
@@ -315,8 +315,8 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 		return 1;
 	}
 	if (bmf.pathname[0]) {
-		if (strcmp(s->bitmap_file,"none")==0) {
-			if (ioctl(fd, SET_BITMAP_FILE, -1)!= 0) {
+		if (strcmp(s->bitmap_file,"none") == 0) {
+			if (ioctl(fd, SET_BITMAP_FILE, -1) != 0) {
 				pr_err("failed to remove bitmap %s\n",
 					bmf.pathname);
 				return 1;
@@ -331,11 +331,11 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 		pr_err("cannot get array status for %s\n", devname);
 		return 1;
 	}
-	if (array.state & (1<<MD_SB_BITMAP_PRESENT)) {
+	if (array.state & (1 << MD_SB_BITMAP_PRESENT)) {
 		if (strcmp(s->bitmap_file, "none")==0) {
-			array.state &= ~(1<<MD_SB_BITMAP_PRESENT);
-			if (ioctl(fd, SET_ARRAY_INFO, &array)!= 0) {
-				if (array.state & (1<<MD_SB_CLUSTERED))
+			array.state &= ~(1 << MD_SB_BITMAP_PRESENT);
+			if (ioctl(fd, SET_ARRAY_INFO, &array) != 0) {
+				if (array.state & (1 << MD_SB_CLUSTERED))
 					pr_err("failed to remove clustered bitmap.\n");
 				else
 					pr_err("failed to remove internal bitmap.\n");
@@ -359,7 +359,7 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 	bitmapsize = array.size;
 	bitmapsize <<= 1;
 	if (get_dev_size(fd, NULL, &array_size) &&
-	    array_size > (0x7fffffffULL<<9)) {
+	    array_size > (0x7fffffffULL << 9)) {
 		/* Array is big enough that we cannot trust array.size
 		 * try other approaches
 		 */
@@ -371,7 +371,9 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 	}
 
 	if (array.level == 10) {
-		int ncopies = (array.layout&255)*((array.layout>>8)&255);
+		int ncopies;
+
+		ncopies = (array.layout & 255) * ((array.layout >> 8) & 255);
 		bitmapsize = bitmapsize * array.raid_disks / ncopies;
 	}
 
@@ -402,7 +404,7 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 		mdi = sysfs_read(fd, NULL, GET_BITMAP_LOCATION);
 		if (mdi)
 			offset_setable = 1;
-		for (d=0; d< st->max_devs; d++) {
+		for (d = 0; d < st->max_devs; d++) {
 			mdu_disk_info_t disk;
 			char *dv;
 			int fd2;
@@ -410,10 +412,9 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 			disk.number = d;
 			if (ioctl(fd, GET_DISK_INFO, &disk) < 0)
 				continue;
-			if (disk.major == 0 &&
-			    disk.minor == 0)
+			if (disk.major == 0 && disk.minor == 0)
 				continue;
-			if ((disk.state & (1<<MD_DISK_SYNC))==0)
+			if ((disk.state & (1 << MD_DISK_SYNC)) == 0)
 				continue;
 			dv = map_dev(disk.major, disk.minor, 1);
 			if (!dv)
@@ -447,8 +448,8 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 						  mdi->bitmap_offset);
 		} else {
 			if (strcmp(s->bitmap_file, "clustered") == 0)
-				array.state |= (1<<MD_SB_CLUSTERED);
-			array.state |= (1<<MD_SB_BITMAP_PRESENT);
+				array.state |= (1 << MD_SB_CLUSTERED);
+			array.state |= (1 << MD_SB_BITMAP_PRESENT);
 			rv = ioctl(fd, SET_ARRAY_INFO, &array);
 		}
 		if (rv < 0) {
@@ -471,8 +472,8 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 			disk.number = d;
 			if (ioctl(fd, GET_DISK_INFO, &disk) < 0)
 				continue;
-			if ((disk.major==0 && disk.minor==0) ||
-			    (disk.state & (1<<MD_DISK_REMOVED)))
+			if ((disk.major==0 && disk.minor == 0) ||
+			    (disk.state & (1 << MD_DISK_REMOVED)))
 				continue;
 			dv = map_dev(disk.major, disk.minor, 1);
 			if (!dv)
@@ -491,14 +492,14 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 			pr_err("cannot find UUID for array!\n");
 			return 1;
 		}
-		if (CreateBitmap(s->bitmap_file, c->force, (char*)uuid, s->bitmap_chunk,
-				 c->delay, s->write_behind, bitmapsize, major)) {
+		if (CreateBitmap(s->bitmap_file, c->force, (char*)uuid,
+				 s->bitmap_chunk, c->delay, s->write_behind,
+				 bitmapsize, major)) {
 			return 1;
 		}
 		bitmap_fd = open(s->bitmap_file, O_RDWR);
 		if (bitmap_fd < 0) {
-			pr_err("weird: %s cannot be opened\n",
-				s->bitmap_file);
+			pr_err("weird: %s cannot be opened\n", s->bitmap_file);
 			return 1;
 		}
 		if (ioctl(fd, SET_BITMAP_FILE, bitmap_fd) < 0) {

--- a/Grow.c
+++ b/Grow.c
@@ -423,7 +423,7 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 				continue;
 			rv = st->ss->load_super(st, fd2, NULL);
 			if (!rv) {
-				if (st->ss->add_internal_bitmap(
+				if (!st->ss->add_internal_bitmap(
 					    st, &s->bitmap_chunk, c->delay,
 					    s->write_behind, bitmapsize,
 					    offset_setable, major))

--- a/Grow.c
+++ b/Grow.c
@@ -3533,7 +3533,7 @@ int reshape_container(char *container, char *devname,
 		int fd;
 		struct mdstat_ent *mdstat;
 		char *adev;
-		int devid;
+		dev_t devid;
 
 		sysfs_free(cc);
 

--- a/Grow.c
+++ b/Grow.c
@@ -4788,6 +4788,7 @@ int Grow_continue_command(char *devname, int fd,
 	dprintf("Grow continue is run for ");
 	if (st->ss->external == 0) {
 		int d;
+		int cnt = 5;
 		dprintf_cont("native array (%s)\n", devname);
 		if (ioctl(fd, GET_ARRAY_INFO, &array.array) < 0) {
 			pr_err("%s is not an active md array - aborting\n", devname);
@@ -4799,36 +4800,42 @@ int Grow_continue_command(char *devname, int fd,
 		 * FIXME we should really get what we need from
 		 * sysfs
 		 */
-		for (d = 0; d < MAX_DISKS; d++) {
-			mdu_disk_info_t disk;
-			char *dv;
-			int err;
-			disk.number = d;
-			if (ioctl(fd, GET_DISK_INFO, &disk) < 0)
-				continue;
-			if (disk.major == 0 && disk.minor == 0)
-				continue;
-			if ((disk.state & (1 << MD_DISK_ACTIVE)) == 0)
-				continue;
-			dv = map_dev(disk.major, disk.minor, 1);
-			if (!dv)
-				continue;
-			fd2 = dev_open(dv, O_RDONLY);
-			if (fd2 < 0)
-				continue;
-			err = st->ss->load_super(st, fd2, NULL);
-			close(fd2);
-			if (err)
-				continue;
-			break;
-		}
-		if (d == MAX_DISKS) {
-			pr_err("Unable to load metadata for %s\n",
-			       devname);
-			ret_val = 1;
-			goto Grow_continue_command_exit;
-		}
-		st->ss->getinfo_super(st, content, NULL);
+		do {
+			for (d = 0; d < MAX_DISKS; d++) {
+				mdu_disk_info_t disk;
+				char *dv;
+				int err;
+				disk.number = d;
+				if (ioctl(fd, GET_DISK_INFO, &disk) < 0)
+					continue;
+				if (disk.major == 0 && disk.minor == 0)
+					continue;
+				if ((disk.state & (1 << MD_DISK_ACTIVE)) == 0)
+					continue;
+				dv = map_dev(disk.major, disk.minor, 1);
+				if (!dv)
+					continue;
+				fd2 = dev_open(dv, O_RDONLY);
+				if (fd2 < 0)
+					continue;
+				err = st->ss->load_super(st, fd2, NULL);
+				close(fd2);
+				if (err)
+					continue;
+				break;
+			}
+			if (d == MAX_DISKS) {
+				pr_err("Unable to load metadata for %s\n",
+				       devname);
+				ret_val = 1;
+				goto Grow_continue_command_exit;
+			}
+			st->ss->getinfo_super(st, content, NULL);
+			if (!content->reshape_active)
+				sleep(3);
+			else
+				break;
+		} while (cnt-- > 0);
 	} else {
 		char *container;
 

--- a/Grow.c
+++ b/Grow.c
@@ -421,7 +421,8 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 			fd2 = dev_open(dv, O_RDWR);
 			if (fd2 < 0)
 				continue;
-			if (st->ss->load_super(st, fd2, NULL)==0) {
+			rv = st->ss->load_super(st, fd2, NULL);
+			if (!rv) {
 				if (st->ss->add_internal_bitmap(
 					    st, &s->bitmap_chunk, c->delay,
 					    s->write_behind, bitmapsize,
@@ -432,6 +433,10 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 					close(fd2);
 					return 1;
 				}
+			} else {
+				pr_err("failed to load super-block.\n");
+				close(fd2);
+				return 1;
 			}
 			close(fd2);
 		}

--- a/Grow.c
+++ b/Grow.c
@@ -423,22 +423,22 @@ int Grow_addbitmap(char *devname, int fd, struct context *c, struct shape *s)
 				continue;
 			rv = st->ss->load_super(st, fd2, NULL);
 			if (!rv) {
-				if (!st->ss->add_internal_bitmap(
-					    st, &s->bitmap_chunk, c->delay,
-					    s->write_behind, bitmapsize,
-					    offset_setable, major))
-					st->ss->write_bitmap(st, fd2, NodeNumUpdate);
-				else {
+				rv = st->ss->add_internal_bitmap(
+					st, &s->bitmap_chunk, c->delay,
+					s->write_behind, bitmapsize,
+					offset_setable, major);
+				if (!rv) {
+					st->ss->write_bitmap(st, fd2,
+							     NodeNumUpdate);
+				} else {
 					pr_err("failed to create internal bitmap - chunksize problem.\n");
-					close(fd2);
-					return 1;
 				}
 			} else {
 				pr_err("failed to load super-block.\n");
-				close(fd2);
-				return 1;
 			}
 			close(fd2);
+			if (rv)
+				return 1;
 		}
 		if (offset_setable) {
 			st->ss->getinfo_super(st, mdi, NULL);

--- a/Incremental.c
+++ b/Incremental.c
@@ -1347,8 +1347,12 @@ restart:
 
 		if (devnm && strcmp(devnm, me->devnm) != 0)
 			continue;
-		if (devnm && me->metadata[0] == '/') {
+		if (me->metadata[0] == '/') {
 			char *sl;
+
+			if (!devnm)
+				continue;
+
 			/* member array, need to work on container */
 			strncpy(container, me->metadata+1, 32);
 			container[31] = 0;

--- a/Manage.c
+++ b/Manage.c
@@ -1395,7 +1395,8 @@ int Manage_subdevs(char *devname, int fd,
 	for (dv = devlist; dv; dv = dv->next) {
 		unsigned long rdev = 0; /* device to add/remove etc */
 		int rv;
-		int mj,mn;
+		int mj;
+		unsigned long mn;
 
 		raid_slot = -1;
 		if (dv->disposition == 'c') {
@@ -1501,7 +1502,7 @@ int Manage_subdevs(char *devname, int fd,
 			if (sysfd >= 0) {
 				char dn[20];
 				if (sysfs_fd_get_str(sysfd, dn, 20) > 0 &&
-				    sscanf(dn, "%d:%d", &mj,&mn) == 2) {
+				    sscanf(dn, "%d:%lu", &mj,&mn) == 2) {
 					rdev = makedev(mj,mn);
 					found = 1;
 				}

--- a/Monitor.c
+++ b/Monitor.c
@@ -213,6 +213,8 @@ int Monitor(struct mddev_dev *devlist,
 		if (mdstat)
 			free_mdstat(mdstat);
 		mdstat = mdstat_read(oneshot?0:1, 0);
+		if (!mdstat)
+			mdstat_close();
 
 		for (st=statelist; st; st=st->next)
 			if (check_array(st, mdstat, c->test, &info,

--- a/Monitor.c
+++ b/Monitor.c
@@ -597,7 +597,7 @@ static int check_array(struct state *st, struct mdstat_ent *mdstat,
 		} else
 			alert("RebuildFinished", dev, NULL, ainfo);
 		if (sra)
-			free(sra);
+			sysfs_free(sra);
 	}
 	st->percent = mse->percent;
 

--- a/bitmap.c
+++ b/bitmap.c
@@ -350,7 +350,17 @@ int ExamineBitmap(char *filename, int brief, struct supertype *st)
 			st = NULL;
 			free(info);
 			fd = bitmap_file_open(filename, &st, i);
+			if (fd < 0) {
+				printf("   Unable to open bitmap file on node: %i\n", i);
+
+				continue;
+			}
 			info = bitmap_fd_read(fd, brief);
+			if (!info) {
+				close(fd);
+				printf("   Unable to read bitmap on node: %i\n", i);
+				continue;
+			}
 			sb = &info->sb;
 			if (sb->magic != BITMAP_MAGIC)
 				pr_err("invalid bitmap magic 0x%x, the bitmap file appears to be corrupted\n", sb->magic);

--- a/bitmap.c
+++ b/bitmap.c
@@ -47,13 +47,13 @@ mapping_t bitmap_states[] = {
 	{ NULL, -1 }
 };
 
-const char *bitmap_state(int state_num)
+static const char *bitmap_state(int state_num)
 {
 	char *state = map_num(bitmap_states, state_num);
 	return state ? state : "Unknown";
 }
 
-const char *human_chunksize(unsigned long bytes)
+static const char *human_chunksize(unsigned long bytes)
 {
 	static char buf[16];
 	char *suffixes[] = { "B", "KB", "MB", "GB", "TB", NULL };
@@ -95,7 +95,7 @@ static inline int count_dirty_bits_byte(char byte, int num_bits)
 	return num;
 }
 
-int count_dirty_bits(char *buf, int num_bits)
+static int count_dirty_bits(char *buf, int num_bits)
 {
 	int i, num = 0;
 
@@ -109,8 +109,8 @@ int count_dirty_bits(char *buf, int num_bits)
 }
 
 /* calculate the size of the bitmap given the array size and bitmap chunksize */
-unsigned long long bitmap_bits(unsigned long long array_size,
-				unsigned long chunksize)
+static unsigned long long
+bitmap_bits(unsigned long long array_size, unsigned long chunksize)
 {
 	return (array_size * 512 + chunksize - 1) / chunksize;
 }
@@ -123,7 +123,7 @@ unsigned long bitmap_sectors(struct bitmap_super_s *bsb)
 	return (bits + bits_per_sector - 1) / bits_per_sector;
 }
 
-bitmap_info_t *bitmap_fd_read(int fd, int brief)
+static bitmap_info_t *bitmap_fd_read(int fd, int brief)
 {
 	/* Note: fd might be open O_DIRECT, so we must be
 	 * careful to align reads properly
@@ -194,7 +194,8 @@ out:
 	return info;
 }
 
-int bitmap_file_open(char *filename, struct supertype **stp, int node_num)
+static int
+bitmap_file_open(char *filename, struct supertype **stp, int node_num)
 {
 	int fd;
 	struct stat stb;
@@ -240,7 +241,7 @@ int bitmap_file_open(char *filename, struct supertype **stp, int node_num)
 	return fd;
 }
 
-__u32 swapl(__u32 l)
+static __u32 swapl(__u32 l)
 {
 	char *c = (char*)&l;
 	char t= c[0];

--- a/config.c
+++ b/config.c
@@ -144,8 +144,7 @@ struct mddev_dev *load_partitions(void)
 		name = map_dev(major, minor, 1);
 		if (!name)
 			continue;
-		d = xmalloc(sizeof(*d));
-		memset(d, 0, sizeof(*d));
+		d = xcalloc(1, sizeof(*d));
 		d->devname = xstrdup(name);
 		d->next = rv;
 		rv = d;
@@ -169,8 +168,7 @@ struct mddev_dev *load_containers(void)
 		if (ent->metadata_version &&
 		    strncmp(ent->metadata_version, "external:", 9) == 0 &&
 		    !is_subarray(&ent->metadata_version[9])) {
-			d = xmalloc(sizeof(*d));
-			memset(d, 0, sizeof(*d));
+			d = xcalloc(1, sizeof(*d));
 			me = map_by_devnm(&map, ent->devnm);
 			if (me)
 				d->devname = xstrdup(me->path);
@@ -971,8 +969,8 @@ struct mddev_dev *conf_get_devs()
 	}
 	if (flags & GLOB_APPEND) {
 		for (i=0; i<globbuf.gl_pathc; i++) {
-			struct mddev_dev *t = xmalloc(sizeof(*t));
-			memset(t, 0, sizeof(*t));
+			struct mddev_dev *t;
+			t = xcalloc(1, sizeof(*t));
 			t->devname = xstrdup(globbuf.gl_pathv[i]);
 			t->next = dlist;
 			dlist = t;

--- a/config.c
+++ b/config.c
@@ -106,11 +106,13 @@ int match_keyword(char *word)
 	int len = strlen(word);
 	int n;
 
-	if (len < 3) return -1;
-	for (n=0; keywords[n]; n++) {
-		if (strncasecmp(word, keywords[n], len)==0)
+	if (len < 3)
+		return -1;
+	for (n = 0; keywords[n]; n++) {
+		if (strncasecmp(word, keywords[n], len) == 0)
 			return n;
 	}
+
 	return -1;
 }
 
@@ -124,6 +126,7 @@ struct mddev_dev *load_partitions(void)
 	FILE *f = fopen("/proc/partitions", "r");
 	char buf[1024];
 	struct mddev_dev *rv = NULL;
+
 	if (f == NULL) {
 		pr_err("cannot open /proc/partitions\n");
 		return NULL;
@@ -203,12 +206,12 @@ int parse_auto(char *str, char *msg, int config)
 	int autof;
 	if (str == NULL || *str == 0)
 		autof = 2;
-	else if (strcasecmp(str,"no")==0)
+	else if (strcasecmp(str, "no") == 0)
 		autof = 1;
-	else if (strcasecmp(str,"yes")==0)
+	else if (strcasecmp(str, "yes") == 0)
 		autof = 2;
-	else if (strcasecmp(str,"md")==0)
-		autof = config?5:3;
+	else if (strcasecmp(str, "md") == 0)
+		autof = config ? 5:3;
 	else {
 		/* There might be digits, and maybe a hypen, at the end */
 		char *e = str + strlen(str);
@@ -218,19 +221,20 @@ int parse_auto(char *str, char *msg, int config)
 			e--;
 		if (*e) {
 			num = atoi(e);
-			if (num <= 0) num = 1;
+			if (num <= 0)
+				num = 1;
 		}
 		if (e > str && e[-1] == '-')
 			e--;
 		len = e - str;
-		if ((len == 2 && strncasecmp(str,"md",2)==0)) {
+		if ((len == 2 && strncasecmp(str, "md", 2) == 0)) {
 			autof = config ? 5 : 3;
-		} else if ((len == 3 && strncasecmp(str,"yes",3)==0)) {
+		} else if ((len == 3 && strncasecmp(str, "yes", 3) == 0)) {
 			autof = 2;
-		} else if ((len == 3 && strncasecmp(str,"mdp",3)==0)) {
+		} else if ((len == 3 && strncasecmp(str, "mdp", 3) == 0)) {
 			autof = config ? 6 : 4;
-		} else if ((len == 1 && strncasecmp(str,"p",1)==0) ||
-			   (len >= 4 && strncasecmp(str,"part",4)==0)) {
+		} else if ((len == 1 && strncasecmp(str, "p", 1) == 0) ||
+			   (len >= 4 && strncasecmp(str, "part", 4) == 0)) {
 			autof = 6;
 		} else {
 			pr_err("%s arg of \"%s\" unrecognised: use no,yes,md,mdp,part\n"
@@ -248,56 +252,57 @@ static void createline(char *line)
 	char *w;
 	char *ep;
 
-	for (w=dl_next(line); w!=line; w=dl_next(w)) {
+	for (w = dl_next(line); w != line; w = dl_next(w)) {
 		if (strncasecmp(w, "auto=", 5) == 0)
-			createinfo.autof = parse_auto(w+5, "auto=", 1);
+			createinfo.autof = parse_auto(w + 5, "auto=", 1);
 		else if (strncasecmp(w, "owner=", 6) == 0) {
 			if (w[6] == 0) {
 				pr_err("missing owner name\n");
 				continue;
 			}
-			createinfo.uid = strtoul(w+6, &ep, 10);
+			createinfo.uid = strtoul(w + 6, &ep, 10);
 			if (*ep != 0) {
 				struct passwd *pw;
 				/* must be a name */
-				pw = getpwnam(w+6);
+				pw = getpwnam(w + 6);
 				if (pw)
 					createinfo.uid = pw->pw_uid;
 				else
-					pr_err("CREATE user %s not found\n", w+6);
+					pr_err("CREATE user %s not found\n",
+					       w + 6);
 			}
 		} else if (strncasecmp(w, "group=", 6) == 0) {
 			if (w[6] == 0) {
 				pr_err("missing group name\n");
 				continue;
 			}
-			createinfo.gid = strtoul(w+6, &ep, 10);
+			createinfo.gid = strtoul(w + 6, &ep, 10);
 			if (*ep != 0) {
 				struct group *gr;
 				/* must be a name */
-				gr = getgrnam(w+6);
+				gr = getgrnam(w + 6);
 				if (gr)
 					createinfo.gid = gr->gr_gid;
 				else
-					pr_err("CREATE group %s not found\n", w+6);
+					pr_err("CREATE group %s not found\n",
+					       w + 6);
 			}
 		} else if (strncasecmp(w, "mode=", 5) == 0) {
 			if (w[5] == 0) {
 				pr_err("missing CREATE mode\n");
 				continue;
 			}
-			createinfo.mode = strtoul(w+5, &ep, 8);
+			createinfo.mode = strtoul(w + 5, &ep, 8);
 			if (*ep != 0) {
 				createinfo.mode = 0600;
 				pr_err("unrecognised CREATE mode %s\n",
-					w+5);
+					w + 5);
 			}
 		} else if (strncasecmp(w, "metadata=", 9) == 0) {
 			/* style of metadata to use by default */
 			int i;
-			for (i=0; superlist[i] && !createinfo.supertype; i++)
-				createinfo.supertype =
-					superlist[i]->match_metadata_desc(w+9);
+			for (i = 0; superlist[i] && !createinfo.supertype; i++)
+				createinfo.supertype = superlist[i]->match_metadata_desc(w + 9);
 			if (!createinfo.supertype)
 				pr_err("metadata format %s unknown, ignoring\n",
 					w+9);
@@ -325,7 +330,7 @@ void devline(char *line)
 	char *w;
 	struct conf_dev *cd;
 
-	for (w=dl_next(line); w != line; w=dl_next(w)) {
+	for (w = dl_next(line); w != line; w = dl_next(w)) {
 		if (w[0] == '/' || strcasecmp(w, "partitions") == 0 ||
 		    strcasecmp(w, "containers") == 0) {
 			cd = xmalloc(sizeof(*cd));
@@ -333,8 +338,7 @@ void devline(char *line)
 			cd->next = cdevlist;
 			cdevlist = cd;
 		} else {
-			pr_err("unreconised word on DEVICE line: %s\n",
-				w);
+			pr_err("unreconised word on DEVICE line: %s\n", w);
 		}
 	}
 }
@@ -377,7 +381,7 @@ void arrayline(char *line)
 	mis.container = NULL;
 	mis.member = NULL;
 
-	for (w=dl_next(line); w!=line; w=dl_next(w)) {
+	for (w = dl_next(line); w != line; w = dl_next(w)) {
 		if (w[0] == '/' || strchr(w, '=') == NULL) {
 			/* This names the device, or is '<ignore>'.
 			 * The rules match those in create_mddev.
@@ -392,10 +396,9 @@ void arrayline(char *line)
 			    strncmp(w, "/dev/md/", 8) == 0 ||
 			    (w[0] != '/' && w[0] != '<') ||
 			    (strncmp(w, "/dev/md", 7) == 0 &&
-			     is_number(w+7)) ||
+			     is_number(w + 7)) ||
 			    (strncmp(w, "/dev/md_d", 9) == 0 &&
-			     is_number(w+9))
-				) {
+			     is_number(w + 9))) {
 				/* This is acceptable */;
 				if (mis.devname)
 					pr_err("only give one device per ARRAY line: %s and %s\n",
@@ -405,89 +408,91 @@ void arrayline(char *line)
 			}else {
 				pr_err("%s is an invalid name for an md device - ignored.\n", w);
 			}
-		} else if (strncasecmp(w, "uuid=", 5)==0 ) {
+		} else if (strncasecmp(w, "uuid=", 5) == 0) {
 			if (mis.uuid_set)
 				pr_err("only specify uuid once, %s ignored.\n",
-					w);
+				       w);
 			else {
-				if (parse_uuid(w+5, mis.uuid))
+				if (parse_uuid(w + 5, mis.uuid))
 					mis.uuid_set = 1;
 				else
 					pr_err("bad uuid: %s\n", w);
 			}
-		} else if (strncasecmp(w, "super-minor=", 12)==0 ) {
+		} else if (strncasecmp(w, "super-minor=", 12) == 0) {
 			if (mis.super_minor != UnSet)
 				pr_err("only specify super-minor once, %s ignored.\n",
 					w);
 			else {
 				char *endptr;
-				int minor = strtol(w+12, &endptr, 10);
+				int minor = strtol(w + 12, &endptr, 10);
 
-				if (w[12]==0 || endptr[0]!=0 || minor < 0)
+				if (w[12] == 0 || endptr[0] != 0 || minor < 0)
 					pr_err("invalid super-minor number: %s\n",
-						w);
+					       w);
 				else
 					mis.super_minor = minor;
 			}
-		} else if (strncasecmp(w, "name=", 5)==0) {
+		} else if (strncasecmp(w, "name=", 5) == 0) {
 			if (mis.name[0])
 				pr_err("only specify name once, %s ignored.\n",
 					w);
-			else if (strlen(w+5) > 32)
+			else if (strlen(w + 5) > 32)
 				pr_err("name too long, ignoring %s\n", w);
 			else
-				strcpy(mis.name, w+5);
+				strcpy(mis.name, w + 5);
 
 		} else if (strncasecmp(w, "bitmap=", 7) == 0) {
 			if (mis.bitmap_file)
 				pr_err("only specify bitmap file once. %s ignored\n",
 					w);
 			else
-				mis.bitmap_file = xstrdup(w+7);
+				mis.bitmap_file = xstrdup(w + 7);
 
-		} else if (strncasecmp(w, "devices=", 8 ) == 0 ) {
+		} else if (strncasecmp(w, "devices=", 8 ) == 0) {
 			if (mis.devices)
 				pr_err("only specify devices once (use a comma separated list). %s ignored\n",
 					w);
 			else
-				mis.devices = xstrdup(w+8);
-		} else if (strncasecmp(w, "spare-group=", 12) == 0 ) {
+				mis.devices = xstrdup(w + 8);
+		} else if (strncasecmp(w, "spare-group=", 12) == 0) {
 			if (mis.spare_group)
 				pr_err("only specify one spare group per array. %s ignored.\n",
 					w);
 			else
-				mis.spare_group = xstrdup(w+12);
+				mis.spare_group = xstrdup(w + 12);
 		} else if (strncasecmp(w, "level=", 6) == 0 ) {
 			/* this is mainly for compatability with --brief output */
-			mis.level = map_name(pers, w+6);
-		} else if (strncasecmp(w, "disks=", 6) == 0 ) {
+			mis.level = map_name(pers, w + 6);
+		} else if (strncasecmp(w, "disks=", 6) == 0) {
 			/* again, for compat */
-			mis.raid_disks = atoi(w+6);
-		} else if (strncasecmp(w, "num-devices=", 12) == 0 ) {
+			mis.raid_disks = atoi(w + 6);
+		} else if (strncasecmp(w, "num-devices=", 12) == 0) {
 			/* again, for compat */
-			mis.raid_disks = atoi(w+12);
-		} else if (strncasecmp(w, "spares=", 7) == 0 ) {
+			mis.raid_disks = atoi(w + 12);
+		} else if (strncasecmp(w, "spares=", 7) == 0) {
 			/* for warning if not all spares present */
-			mis.spare_disks = atoi(w+7);
+			mis.spare_disks = atoi(w + 7);
 		} else if (strncasecmp(w, "metadata=", 9) == 0) {
 			/* style of metadata on the devices. */
 			int i;
 
 			for(i=0; superlist[i] && !mis.st; i++)
-				mis.st = superlist[i]->match_metadata_desc(w+9);
+				mis.st = superlist[i]->
+					match_metadata_desc(w + 9);
 
 			if (!mis.st)
-				pr_err("metadata format %s unknown, ignored.\n", w+9);
+				pr_err("metadata format %s unknown, ignored.\n",
+				       w + 9);
 		} else if (strncasecmp(w, "auto=", 5) == 0 ) {
 			/* whether to create device special files as needed */
-			mis.autof = parse_auto(w+5, "auto type", 0);
+			mis.autof = parse_auto(w + 5, "auto type", 0);
 		} else if (strncasecmp(w, "member=", 7) == 0) {
 			/* subarray within a container */
-			mis.member = xstrdup(w+7);
+			mis.member = xstrdup(w + 7);
 		} else if (strncasecmp(w, "container=", 10) == 0) {
-			/* the container holding this subarray.  Either a device name
-			 * or a uuid */
-			mis.container = xstrdup(w+10);
+			/* The container holding this subarray.
+			 * Either a device name or a uuid */
+			mis.container = xstrdup(w + 10);
 		} else {
 			pr_err("unrecognised word on ARRAY line: %s\n",
 				w);
@@ -496,7 +501,8 @@ void arrayline(char *line)
 	if (mis.uuid_set == 0 && mis.devices == NULL &&
 	    mis.super_minor == UnSet && mis.name[0] == 0 &&
 	    (mis.container == NULL || mis.member == NULL))
-		pr_err("ARRAY line %s has no identity information.\n", mis.devname);
+		pr_err("ARRAY line %s has no identity information.\n",
+		       mis.devname);
 	else {
 		mi = xmalloc(sizeof(*mi));
 		*mi = mis;
@@ -512,7 +518,7 @@ void mailline(char *line)
 {
 	char *w;
 
-	for (w=dl_next(line); w != line ; w=dl_next(w))
+	for (w = dl_next(line); w != line; w = dl_next(w))
 		if (alert_email == NULL)
 			alert_email = xstrdup(w);
 }
@@ -522,7 +528,7 @@ void mailfromline(char *line)
 {
 	char *w;
 
-	for (w=dl_next(line); w != line ; w=dl_next(w)) {
+	for (w = dl_next(line); w != line; w = dl_next(w)) {
 		if (alert_mail_from == NULL)
 			alert_mail_from = xstrdup(w);
 		else {
@@ -541,7 +547,7 @@ void programline(char *line)
 {
 	char *w;
 
-	for (w=dl_next(line); w != line ; w=dl_next(w))
+	for (w = dl_next(line); w != line; w = dl_next(w))
 		if (alert_program == NULL)
 			alert_program = xstrdup(w);
 }
@@ -552,11 +558,11 @@ void homehostline(char *line)
 {
 	char *w;
 
-	for (w=dl_next(line); w != line ; w=dl_next(w)) {
-		if (strcasecmp(w, "<ignore>")==0)
+	for (w = dl_next(line); w != line; w = dl_next(w)) {
+		if (strcasecmp(w, "<ignore>") == 0)
 			require_homehost = 0;
 		else if (home_host == NULL) {
-			if (strcasecmp(w, "<none>")==0)
+			if (strcasecmp(w, "<none>") == 0)
 				home_host = xstrdup("");
 			else
 				home_host = xstrdup(w);
@@ -569,9 +575,9 @@ void homeclusterline(char *line)
 {
 	char *w;
 
-	for (w=dl_next(line); w != line ; w=dl_next(w)) {
+	for (w = dl_next(line); w != line; w = dl_next(w)) {
 		if (home_cluster == NULL) {
-			if (strcasecmp(w, "<none>")==0)
+			if (strcasecmp(w, "<none>") == 0)
 				home_cluster = xstrdup("");
 			else
 				home_cluster = xstrdup(w);
@@ -597,7 +603,9 @@ void autoline(char *line)
 		return;
 	auto_seen = 1;
 
-	/* Parse the 'auto' line creating policy statements for the 'auto' policy.
+	/*
+	 * Parse the 'auto' line creating policy statements for the 'auto'
+	 * policy.
 	 *
 	 * The default is 'yes' but the 'auto' line might over-ride that.
 	 * Words in the line are processed in order with the first
@@ -623,7 +631,8 @@ void autoline(char *line)
 	 * been seen gets an appropriate auto= entry.
 	 */
 
-	/* If environment variable MDADM_CONF_AUTO is defined, then
+	/*
+	 * If environment variable MDADM_CONF_AUTO is defined, then
 	 * it is prepended to the auto line.  This allow a script
 	 * to easily disable some metadata types.
 	 */
@@ -645,7 +654,7 @@ void autoline(char *line)
 		;
 	seen = xcalloc(super_cnt, 1);
 
-	for (w = dl_next(line); w != line ; w = dl_next(w)) {
+	for (w = dl_next(line); w != line; w = dl_next(w)) {
 		char *val;
 
 		if (strcasecmp(w, "yes") == 0) {
@@ -673,22 +682,21 @@ void autoline(char *line)
 		} else
 			continue;
 
-		if (strcasecmp(w+1, "all") == 0) {
+		if (strcasecmp(w + 1, "all") == 0) {
 			dflt = val;
 			break;
 		}
 		for (i = 0; superlist[i]; i++) {
 			const char *version = superlist[i]->name;
-			if (strcasecmp(w+1, version) == 0)
+			if (strcasecmp(w + 1, version) == 0)
 				break;
 			/* 1 matches 1.x, 0 matches 0.90 */
-			if (version[1] == '.' &&
-			    strlen(w+1) == 1 &&
+			if (version[1] == '.' && strlen(w + 1) == 1 &&
 			    w[1] == version[0])
 				break;
 			/* 1.anything matches 1.x */
 			if (strcmp(version, "1.x") == 0 &&
-			    strncmp(w+1, "1.", 2) == 0)
+			    strncmp(w + 1, "1.", 2) == 0)
 				break;
 		}
 		if (superlist[i] == NULL)
@@ -697,12 +705,14 @@ void autoline(char *line)
 		if (seen[i])
 			/* already know about this metadata */
 			continue;
-		policy_add(rule_policy, pol_auto, val, pol_metadata, superlist[i]->name, NULL);
+		policy_add(rule_policy, pol_auto, val, pol_metadata,
+			   superlist[i]->name, NULL);
 		seen[i] = 1;
 	}
 	for (i = 0; i < super_cnt; i++)
 		if (!seen[i])
-			policy_add(rule_policy, pol_auto, dflt, pol_metadata, superlist[i]->name, NULL);
+			policy_add(rule_policy, pol_auto, dflt, pol_metadata,
+				   superlist[i]->name, NULL);
 
 	free(seen);
 }
@@ -718,7 +728,7 @@ void set_conffile(char *file)
 void conf_file(FILE *f)
 {
 	char *line;
-	while ((line=conf_line(f))) {
+	while ((line = conf_line(f))) {
 		switch(match_keyword(line)) {
 		case Devices:
 			devline(line);
@@ -789,9 +799,9 @@ void conf_file_or_dir(FILE *f)
 		if (dp->d_name[0] == '.')
 			continue;
 		l = strlen(dp->d_name);
-		if (l < 6 || strcmp(dp->d_name+l-5, ".conf") != 0)
+		if (l < 6 || strcmp(dp->d_name + l - 5, ".conf") != 0)
 			continue;
-		fn = xmalloc(sizeof(*fn)+l+1);
+		fn = xmalloc(sizeof(*fn) + l + 1);
 		strcpy(fn->name, dp->d_name);
 		for (p = &list;
 		     *p && strcmp((*p)->name, fn->name) < 0;
@@ -834,7 +844,7 @@ void load_conffile(void)
 		confdir = DefaultConfDir;
 	}
 
-	if (strcmp(conffile, "partitions")==0) {
+	if (strcmp(conffile, "partitions") == 0) {
 		char *list = dl_strdup("DEV");
 		dl_init(list);
 		dl_add(list, dl_strdup("partitions"));
@@ -847,8 +857,7 @@ void load_conffile(void)
 		 * have a working mdadm, we read /etc/mdadm/mdadm.conf
 		 * if /etc/mdadm.conf doesn't exist
 		 */
-		if (f == NULL &&
-		    conffile == DefaultConfFile) {
+		if (f == NULL && conffile == DefaultConfFile) {
 			f = fopen(DefaultAltConfFile, "r");
 			if (f) {
 				conffile = DefaultAltConfFile;
@@ -921,8 +930,8 @@ struct mddev_ident *conf_get_ident(char *dev)
 	struct mddev_ident *rv;
 	load_conffile();
 	rv = mddevlist;
-	while (dev && rv && (rv->devname == NULL
-			     || !devname_matches(dev, rv->devname)))
+	while (dev && rv && (rv->devname == NULL ||
+			     !devname_matches(dev, rv->devname)))
 		rv = rv->next;
 	return rv;
 }
@@ -957,10 +966,10 @@ struct mddev_dev *conf_get_devs()
 		append_dlist(&dlist, load_containers());
 	}
 
-	for (cd=cdevlist; cd; cd=cd->next) {
-		if (strcasecmp(cd->name, "partitions")==0)
+	for (cd = cdevlist; cd; cd = cd->next) {
+		if (strcasecmp(cd->name, "partitions") == 0)
 			append_dlist(&dlist, load_partitions());
-		else if (strcasecmp(cd->name, "containers")==0)
+		else if (strcasecmp(cd->name, "containers") == 0)
 			append_dlist(&dlist, load_containers());
 		else {
 			glob(cd->name, flags, NULL, &globbuf);
@@ -968,7 +977,7 @@ struct mddev_dev *conf_get_devs()
 		}
 	}
 	if (flags & GLOB_APPEND) {
-		for (i=0; i<globbuf.gl_pathc; i++) {
+		for (i = 0; i < globbuf.gl_pathc; i++) {
 			struct mddev_dev *t;
 			t = xcalloc(1, sizeof(*t));
 			t->devname = xstrdup(globbuf.gl_pathv[i]);
@@ -988,7 +997,7 @@ int conf_test_dev(char *devname)
 	if (cdevlist == NULL)
 		/* allow anything by default */
 		return 1;
-	for (cd = cdevlist ; cd ; cd = cd->next) {
+	for (cd = cdevlist; cd; cd = cd->next) {
 		if (strcasecmp(cd->name, "partitions") == 0)
 			return 1;
 		if (fnmatch(cd->name, devname, FNM_PATHNAME) == 0)
@@ -1005,7 +1014,7 @@ int conf_test_metadata(const char *version, struct dev_policy *pol, int is_homeh
 	 * else 'yes'.
 	 */
 	struct dev_policy *p;
-	int no=0, found_homehost=0;
+	int no = 0, found_homehost = 0;
 	load_conffile();
 
 	pol = pol_find(pol, pol_auto);
@@ -1037,9 +1046,9 @@ int match_oneof(char *devices, char *devname)
 		if (!devices)
 			devices = p + strlen(p);
 		if (devices-p < 1024) {
-			strncpy(patn, p, devices-p);
+			strncpy(patn, p, devices - p);
 			patn[devices-p] = 0;
-			if (fnmatch(patn, devname, FNM_PATHNAME)==0)
+			if (fnmatch(patn, devname, FNM_PATHNAME) == 0)
 				return 1;
 		}
 		if (*devices == ',')
@@ -1068,11 +1077,9 @@ int devname_matches(char *name, char *match)
 	else if (strncmp(match, "/dev/", 5) == 0)
 		match += 5;
 
-	if (strncmp(name, "md", 2) == 0 &&
-	    isdigit(name[2]))
+	if (strncmp(name, "md", 2) == 0 && isdigit(name[2]))
 		name += 2;
-	if (strncmp(match, "md", 2) == 0 &&
-	    isdigit(match[2]))
+	if (strncmp(match, "md", 2) == 0 && isdigit(match[2]))
 		match += 2;
 
 	return (strcmp(name, match) == 0);
@@ -1095,8 +1102,7 @@ int conf_name_is_free(char *name)
 		if (dev->name[0] && devname_matches(name, dev->name))
 			return 0;
 		sprintf(nbuf, "%d", dev->super_minor);
-		if (dev->super_minor != UnSet &&
-		    devname_matches(name, nbuf))
+		if (dev->super_minor != UnSet && devname_matches(name, nbuf))
 			return 0;
 	}
 	return 1;
@@ -1140,10 +1146,8 @@ struct mddev_ident *conf_match(struct supertype *st,
 				       array_list->devname);
 			continue;
 		}
-		if (!array_list->uuid_set &&
-		    !array_list->name[0] &&
-		    !array_list->devices &&
-		    array_list->super_minor == UnSet) {
+		if (!array_list->uuid_set && !array_list->name[0] &&
+		    !array_list->devices && array_list->super_minor == UnSet) {
 			if (verbose >= 2 && array_list->devname)
 				pr_err("%s doesn't have any identifying information.\n",
 				       array_list->devname);

--- a/lib.c
+++ b/lib.c
@@ -99,7 +99,7 @@ char *fd2kname(int fd)
 	return NULL;
 }
 
-char *devid2devnm(int devid)
+char *devid2devnm(dev_t devid)
 {
 	char path[30];
 	char link[200];

--- a/lib.c
+++ b/lib.c
@@ -226,7 +226,7 @@ char *map_dev_preferred(int major, int minor, int create,
 	int did_check = 0;
 
 	if (major == 0 && minor == 0)
-			return NULL;
+		return NULL;
 
  retry:
 	if (!devlist_ready) {
@@ -464,7 +464,8 @@ char *conf_line(FILE *file)
 	char *list;
 
 	w = conf_word(file, 1);
-	if (w == NULL) return NULL;
+	if (w == NULL)
+		return NULL;
 
 	list = dl_strdup(w);
 	free(w);

--- a/mapfile.c
+++ b/mapfile.c
@@ -374,7 +374,7 @@ void RebuildMap(void)
 			char dn[30];
 			int dfd;
 			int ok;
-			int devid;
+			dev_t devid;
 			struct supertype *st;
 			char *subarray = NULL;
 			char *path;

--- a/mdadm.8.in
+++ b/mdadm.8.in
@@ -1444,6 +1444,14 @@ number. The receiving node must acknowledge this message
 with \-\-cluster\-confirm. Valid arguments are <slot>:<devicename> in case
 the device is found or <slot>:missing in case the device is not found.
 
+.TP
+.BR \-\-add-journal
+Recreate journal for RAID-4/5/6 array that lost a journal device. In the
+current implementation, this command cannot add a journal to an array
+that had a failed journal. To avoid interrupting on-going write opertions,
+.B \-\-add-journal
+only works for array in Read-Only state.
+
 .P
 Each of these options requires that the first device listed is the array
 to be acted upon, and the remainder are component devices to be added,

--- a/mdadm.c
+++ b/mdadm.c
@@ -1142,7 +1142,7 @@ int main(int argc, char *argv[])
 				continue;
 			}
 			/* probable typo */
-			pr_err("bitmap file must contain a '/', or be 'internal', or 'none'\n"
+			pr_err("bitmap file must contain a '/', or be 'internal', or be 'clustered', or 'none'\n"
 				"       not '%s'\n", optarg);
 			exit(2);
 

--- a/mdadm.h
+++ b/mdadm.h
@@ -1440,8 +1440,8 @@ extern char *find_free_devnm(int use_partitions);
 
 extern void put_md_name(char *name);
 extern char *devid2kname(int devid);
-extern char *devid2devnm(int devid);
-extern int devnm2devid(char *devnm);
+extern char *devid2devnm(dev_t devid);
+extern dev_t devnm2devid(char *devnm);
 extern char *get_md_name(char *devnm);
 
 extern char DefaultConfFile[];

--- a/mdadm.h
+++ b/mdadm.h
@@ -45,6 +45,10 @@ extern __off64_t lseek64 __P ((int __fd, __off64_t __offset, int __whence));
 #include	<errno.h>
 #include	<string.h>
 #include	<syslog.h>
+#ifdef __GLIBC__
+/* Newer glibc requires sys/sysmacros.h directly for makedev() */
+#include	<sys/sysmacros.h>
+#endif
 #ifdef __dietlibc__
 #include	<strings.h>
 /* dietlibc has deprecated random and srandom!! */

--- a/mdadm.h
+++ b/mdadm.h
@@ -896,6 +896,8 @@ extern struct superswitch {
 	 * created, in which case data_size may be updated, or it might
 	 * already exist.  Metadata handler can know if init_super
 	 * has been called, but not write_init_super.
+	 *  0:     Success
+	 * -Exxxx: On error
 	 */
 	int (*add_internal_bitmap)(struct supertype *st, int *chunkp,
 				   int delay, int write_behind,

--- a/mdadm.h
+++ b/mdadm.h
@@ -289,7 +289,7 @@ struct mdinfo {
 	int container_enough; /* flag external handlers can set to
 			       * indicate that subarrays have not enough (-1),
 			       * enough to start (0), or all expected disks (1) */
-	char		sys_name[20];
+	char		sys_name[32];
 	struct mdinfo *devs;
 	struct mdinfo *next;
 

--- a/mdadm.h
+++ b/mdadm.h
@@ -1470,6 +1470,7 @@ extern int mdmon_running(char *devnm);
 extern int mdmon_pid(char *devnm);
 extern int check_env(char *name);
 extern __u32 random32(void);
+extern void random_uuid(__u8 *buf);
 extern int start_mdmon(char *devnm);
 
 extern int child_monitor(int afd, struct mdinfo *sra, struct reshape *reshape,

--- a/mdadm.h
+++ b/mdadm.h
@@ -1354,7 +1354,7 @@ extern int check_partitions(int fd, char *dname,
 			    unsigned long long size);
 
 extern int get_mdp_major(void);
-extern int get_maj_min(char *dev, int *major, int *minor);
+extern int get_maj_min(char *dev, int *major, unsigned long *minor);
 extern int dev_open(char *dev, int flags);
 extern int open_dev(char *devnm);
 extern void reopen_mddev(int mdfd);

--- a/mdopen.c
+++ b/mdopen.c
@@ -348,7 +348,7 @@ int create_mddev(char *dev, char *name, int autof, int trustworthy,
 		if (lstat(devname, &stb) == 0) {
 			/* Must be the correct device, else error */
 			if ((stb.st_mode&S_IFMT) != S_IFBLK ||
-			    stb.st_rdev != (dev_t)devnm2devid(devnm)) {
+			    stb.st_rdev != devnm2devid(devnm)) {
 				pr_err("%s exists but looks wrong, please fix\n",
 					devname);
 				return -1;
@@ -452,7 +452,7 @@ char *find_free_devnm(int use_partitions)
 		if (!use_udev()) {
 			/* make sure it is new to /dev too, at least as a
 			 * non-standard */
-			int devid = devnm2devid(devnm);
+			dev_t devid = devnm2devid(devnm);
 			if (devid) {
 				char *dn = map_dev(major(devid),
 						   minor(devid), 0);

--- a/mdopen.c
+++ b/mdopen.c
@@ -439,7 +439,7 @@ char *find_free_devnm(int use_partitions)
 	static char devnm[32];
 	int devnum;
 	for (devnum = 127; devnum != 128;
-	     devnum = devnum ? devnum-1 : (1<<20)-1) {
+	     devnum = devnum ? devnum-1 : (1<<9)-1) {
 
 		if (use_partitions)
 			sprintf(devnm, "md_d%d", devnum);

--- a/mdstat.c
+++ b/mdstat.c
@@ -133,7 +133,11 @@ struct mdstat_ent *mdstat_read(int hold, int start)
 	int fd;
 
 	if (hold && mdstat_fd != -1) {
-		lseek(mdstat_fd, 0L, 0);
+		off_t offset = lseek(mdstat_fd, 0L, 0);
+		if (offset == (off_t)-1) {
+			mdstat_close();
+			return NULL;
+		}
 		fd = dup(mdstat_fd);
 		if (fd >= 0)
 			f = fdopen(fd, "r");

--- a/monitor.c
+++ b/monitor.c
@@ -420,6 +420,9 @@ static int read_and_act(struct active_array *a)
 	if (sync_completed > a->last_checkpoint)
 		a->last_checkpoint = sync_completed;
 
+	if (sync_completed >= a->info.component_size)
+		a->last_checkpoint = 0;
+
 	a->container->ss->sync_metadata(a->container);
 	dprintf("(%d): state:%s action:%s next(", a->info.container_member,
 		array_states[a->curr_state], sync_actions[a->curr_action]);

--- a/restripe.c
+++ b/restripe.c
@@ -58,26 +58,30 @@ int geo_map(int block, unsigned long long stripe, int raid_disks,
 		return block;
 	case 500 + ALGORITHM_LEFT_ASYMMETRIC:
 		pd = (raid_disks-1) - stripe % raid_disks;
-		if (block == -1) return pd;
+		if (block == -1)
+			return pd;
 		if (block >= pd)
 			block++;
 		return block;
 
 	case 500 + ALGORITHM_RIGHT_ASYMMETRIC:
 		pd = stripe % raid_disks;
-		if (block == -1) return pd;
+		if (block == -1)
+			return pd;
 		if (block >= pd)
 			block++;
 		return block;
 
 	case 500 + ALGORITHM_LEFT_SYMMETRIC:
 		pd = (raid_disks - 1) - stripe % raid_disks;
-		if (block == -1) return pd;
+		if (block == -1)
+			return pd;
 		return (pd + 1 + block) % raid_disks;
 
 	case 500 + ALGORITHM_RIGHT_SYMMETRIC:
 		pd = stripe % raid_disks;
-		if (block == -1) return pd;
+		if (block == -1)
+			return pd;
 		return (pd + 1 + block) % raid_disks;
 
 	case 500 + ALGORITHM_PARITY_0:
@@ -94,7 +98,8 @@ int geo_map(int block, unsigned long long stripe, int raid_disks,
 			return raid_disks - 1;
 		raid_disks--;
 		pd = (raid_disks-1) - stripe % raid_disks;
-		if (block == -1) return pd;
+		if (block == -1)
+			return pd;
 		if (block >= pd)
 			block++;
 		return block;
@@ -104,7 +109,8 @@ int geo_map(int block, unsigned long long stripe, int raid_disks,
 			return raid_disks - 1;
 		raid_disks--;
 		pd = stripe % raid_disks;
-		if (block == -1) return pd;
+		if (block == -1)
+			return pd;
 		if (block >= pd)
 			block++;
 		return block;
@@ -114,7 +120,8 @@ int geo_map(int block, unsigned long long stripe, int raid_disks,
 			return raid_disks - 1;
 		raid_disks--;
 		pd = (raid_disks - 1) - stripe % raid_disks;
-		if (block == -1) return pd;
+		if (block == -1)
+			return pd;
 		return (pd + 1 + block) % raid_disks;
 
 	case 600 + ALGORITHM_RIGHT_SYMMETRIC_6:
@@ -122,7 +129,8 @@ int geo_map(int block, unsigned long long stripe, int raid_disks,
 			return raid_disks - 1;
 		raid_disks--;
 		pd = stripe % raid_disks;
-		if (block == -1) return pd;
+		if (block == -1)
+			return pd;
 		return (pd + 1 + block) % raid_disks;
 
 	case 600 + ALGORITHM_PARITY_0_6:
@@ -139,8 +147,10 @@ int geo_map(int block, unsigned long long stripe, int raid_disks,
 
 	case 600 + ALGORITHM_LEFT_ASYMMETRIC:
 		pd = raid_disks - 1 - (stripe % raid_disks);
-		if (block == -1) return pd;
-		if (block == -2) return (pd+1) % raid_disks;
+		if (block == -1)
+			return pd;
+		if (block == -2)
+			return (pd+1) % raid_disks;
 		if (pd == raid_disks - 1)
 			return block+1;
 		if (block >= pd)
@@ -151,8 +161,10 @@ int geo_map(int block, unsigned long long stripe, int raid_disks,
 		/* Different order for calculating Q, otherwize same as ... */
 	case 600 + ALGORITHM_RIGHT_ASYMMETRIC:
 		pd = stripe % raid_disks;
-		if (block == -1) return pd;
-		if (block == -2) return (pd+1) % raid_disks;
+		if (block == -1)
+			return pd;
+		if (block == -2)
+			return (pd+1) % raid_disks;
 		if (pd == raid_disks - 1)
 			return block+1;
 		if (block >= pd)
@@ -161,14 +173,18 @@ int geo_map(int block, unsigned long long stripe, int raid_disks,
 
 	case 600 + ALGORITHM_LEFT_SYMMETRIC:
 		pd = raid_disks - 1 - (stripe % raid_disks);
-		if (block == -1) return pd;
-		if (block == -2) return (pd+1) % raid_disks;
+		if (block == -1)
+			return pd;
+		if (block == -2)
+			return (pd+1) % raid_disks;
 		return (pd + 2 + block) % raid_disks;
 
 	case 600 + ALGORITHM_RIGHT_SYMMETRIC:
 		pd = stripe % raid_disks;
-		if (block == -1) return pd;
-		if (block == -2) return (pd+1) % raid_disks;
+		if (block == -1)
+			return pd;
+		if (block == -2)
+			return (pd+1) % raid_disks;
 		return (pd + 2 + block) % raid_disks;
 
 	case 600 + ALGORITHM_ROTATING_N_RESTART:
@@ -177,8 +193,10 @@ int geo_map(int block, unsigned long long stripe, int raid_disks,
 		 * Q D D D P
 		 */
 		pd = raid_disks - 1 - ((stripe + 1) % raid_disks);
-		if (block == -1) return pd;
-		if (block == -2) return (pd+1) % raid_disks;
+		if (block == -1)
+			return pd;
+		if (block == -2)
+			return (pd+1) % raid_disks;
 		if (pd == raid_disks - 1)
 			return block+1;
 		if (block >= pd)
@@ -188,8 +206,10 @@ int geo_map(int block, unsigned long long stripe, int raid_disks,
 	case 600 + ALGORITHM_ROTATING_N_CONTINUE:
 		/* Same as left_symmetric but Q is before P */
 		pd = raid_disks - 1 - (stripe % raid_disks);
-		if (block == -1) return pd;
-		if (block == -2) return (pd+raid_disks-1) % raid_disks;
+		if (block == -1)
+			return pd;
+		if (block == -2)
+			return (pd+raid_disks-1) % raid_disks;
 		return (pd + 1 + block) % raid_disks;
 	}
 	return -1;

--- a/super-intel.c
+++ b/super-intel.c
@@ -10363,6 +10363,33 @@ exit_imsm_reshape_super:
 	return ret_val;
 }
 
+#define COMPLETED_OK		0
+#define COMPLETED_NONE		1
+#define COMPLETED_DELAYED	2
+
+static int read_completed(int fd, unsigned long long *val)
+{
+	int ret;
+	char buf[50];
+
+	ret = sysfs_fd_get_str(fd, buf, 50);
+	if (ret < 0)
+		return ret;
+
+	ret = COMPLETED_OK;
+	if (strncmp(buf, "none", 4) == 0) {
+		ret = COMPLETED_NONE;
+	} else if (strncmp(buf, "delayed", 7) == 0) {
+		ret = COMPLETED_DELAYED;
+	} else {
+		char *ep;
+		*val = strtoull(buf, &ep, 0);
+		if (ep == buf || (*ep != 0 && *ep != '\n' && *ep != ' '))
+			ret = -1;
+	}
+	return ret;
+}
+
 /*******************************************************************************
  * Function:	wait_for_reshape_imsm
  * Description:	Function writes new sync_max value and waits until
@@ -10417,8 +10444,10 @@ int wait_for_reshape_imsm(struct mdinfo *sra, int ndata)
 	}
 
 	do {
+		int rc;
 		char action[20];
 		int timeout = 3000;
+
 		sysfs_wait(fd, &timeout);
 		if (sysfs_get_str(sra, NULL, "sync_action",
 				  action, 20) > 0 &&
@@ -10428,11 +10457,14 @@ int wait_for_reshape_imsm(struct mdinfo *sra, int ndata)
 			close(fd);
 			return -1;
 		}
-		if (sysfs_fd_get_ll(fd, &completed) < 0) {
+
+		rc = read_completed(fd, &completed);
+		if (rc < 0) {
 			dprintf("cannot read reshape_position (in loop)\n");
 			close(fd);
 			return 1;
-		}
+		} else if (rc == COMPLETED_NONE)
+			break;
 	} while (completed < position_to_set);
 
 	close(fd);

--- a/super-intel.c
+++ b/super-intel.c
@@ -10423,6 +10423,8 @@ int wait_for_reshape_imsm(struct mdinfo *sra, int ndata)
 		if (sysfs_get_str(sra, NULL, "sync_action",
 				  action, 20) > 0 &&
 				strncmp(action, "reshape", 7) != 0) {
+			if (strncmp(action, "idle", 4) == 0)
+				break;
 			close(fd);
 			return -1;
 		}
@@ -10432,9 +10434,9 @@ int wait_for_reshape_imsm(struct mdinfo *sra, int ndata)
 			return 1;
 		}
 	} while (completed < position_to_set);
+
 	close(fd);
 	return 0;
-
 }
 
 /*******************************************************************************

--- a/super0.c
+++ b/super0.c
@@ -87,17 +87,17 @@ static void examine_super0(struct supertype *st, char *homehost)
 	char *c;
 
 	printf("          Magic : %08x\n", sb->md_magic);
-	printf("        Version : %d.%02d.%02d\n", sb->major_version, sb->minor_version,
-	       sb->patch_version);
+	printf("        Version : %d.%02d.%02d\n",
+	       sb->major_version, sb->minor_version, sb->patch_version);
 	if (sb->minor_version >= 90) {
-		printf("           UUID : %08x:%08x:%08x:%08x", sb->set_uuid0, sb->set_uuid1,
-		       sb->set_uuid2, sb->set_uuid3);
+		printf("           UUID : %08x:%08x:%08x:%08x", sb->set_uuid0,
+		       sb->set_uuid1, sb->set_uuid2, sb->set_uuid3);
 		if (homehost) {
 			char buf[20];
-			void *hash = sha1_buffer(homehost,
-						 strlen(homehost),
-						 buf);
-			if (memcmp(&sb->set_uuid2, hash, 8)==0)
+			void *hash;
+
+			hash = sha1_buffer(homehost, strlen(homehost), buf);
+			if (memcmp(&sb->set_uuid2, hash, 8) == 0)
 				printf(" (local to host %s)", homehost);
 		}
 		printf("\n");
@@ -109,19 +109,27 @@ static void examine_super0(struct supertype *st, char *homehost)
 
 	atime = sb->ctime;
 	printf("  Creation Time : %.24s\n", ctime(&atime));
-	c=map_num(pers, sb->level);
+	c = map_num(pers, sb->level);
 	printf("     Raid Level : %s\n", c?c:"-unknown-");
 	if ((int)sb->level > 0) {
 		int ddsks = 0, ddsks_denom = 1;
 		printf("  Used Dev Size : %d%s\n", sb->size,
 		       human_size((long long)sb->size<<10));
 		switch(sb->level) {
-		case 1: ddsks=1;break;
+		case 1:
+			ddsks=1;
+			break;
 		case 4:
-		case 5: ddsks = sb->raid_disks-1; break;
-		case 6: ddsks = sb->raid_disks-2; break;
-		case 10: ddsks = sb->raid_disks;
-			ddsks_denom =  (sb->layout&255) * ((sb->layout>>8)&255);
+		case 5:
+			ddsks = sb->raid_disks - 1;
+			break;
+		case 6:
+			ddsks = sb->raid_disks - 2;
+			break;
+		case 10:
+			ddsks = sb->raid_disks;
+			ddsks_denom =
+				(sb->layout & 255) * ((sb->layout >> 8) & 255);
 		}
 		if (ddsks) {
 			long long asize = sb->size;
@@ -134,11 +142,14 @@ static void examine_super0(struct supertype *st, char *homehost)
 	printf("  Total Devices : %d\n", sb->nr_disks);
 	printf("Preferred Minor : %d\n", sb->md_minor);
 	printf("\n");
-	if (sb->minor_version > 90 && (sb->reshape_position+1) != 0) {
-		printf("  Reshape pos'n : %llu%s\n", (unsigned long long)sb->reshape_position/2, human_size((long long)sb->reshape_position<<9));
+	if (sb->minor_version > 90 && (sb->reshape_position + 1) != 0) {
+		printf("  Reshape pos'n : %llu%s\n",
+		       (unsigned long long)sb->reshape_position / 2,
+		       human_size((long long)sb->reshape_position << 9));
 		if (sb->delta_disks) {
 			printf("  Delta Devices : %d", sb->delta_disks);
-			printf(" (%d->%d)\n", sb->raid_disks-sb->delta_disks, sb->raid_disks);
+			printf(" (%d->%d)\n", sb->raid_disks-sb->delta_disks,
+			       sb->raid_disks);
 			if (((int)sb->delta_disks) < 0)
 				delta_extra = - sb->delta_disks;
 		}
@@ -149,11 +160,13 @@ static void examine_super0(struct supertype *st, char *homehost)
 		if (sb->new_layout != sb->layout) {
 			if (sb->level == 5) {
 				c = map_num(r5layout, sb->new_layout);
-				printf("     New Layout : %s\n", c?c:"-unknown-");
+				printf("     New Layout : %s\n",
+				       c?c:"-unknown-");
 			}
 			if (sb->level == 6) {
 				c = map_num(r6layout, sb->new_layout);
-				printf("     New Layout : %s\n", c?c:"-unknown-");
+				printf("     New Layout : %s\n",
+				       c?c:"-unknown-");
 			}
 			if (sb->level == 10) {
 				printf("     New Layout : near=%d, %s=%d\n",
@@ -169,8 +182,8 @@ static void examine_super0(struct supertype *st, char *homehost)
 	atime = sb->utime;
 	printf("    Update Time : %.24s\n", ctime(&atime));
 	printf("          State : %s\n",
-	       (sb->state&(1<<MD_SB_CLEAN))?"clean":"active");
-	if (sb->state & (1<<MD_SB_BITMAP_PRESENT))
+	       (sb->state&(1 << MD_SB_CLEAN)) ? "clean":"active");
+	if (sb->state & (1 << MD_SB_BITMAP_PRESENT))
 		printf("Internal Bitmap : present\n");
 	printf(" Active Devices : %d\n", sb->active_disks);
 	printf("Working Devices : %d\n", sb->working_disks);
@@ -179,10 +192,10 @@ static void examine_super0(struct supertype *st, char *homehost)
 	if (calc_sb0_csum(sb) == sb->sb_csum)
 		printf("       Checksum : %x - correct\n", sb->sb_csum);
 	else
-		printf("       Checksum : %x - expected %lx\n", sb->sb_csum, calc_sb0_csum(sb));
+		printf("       Checksum : %x - expected %lx\n",
+		       sb->sb_csum, calc_sb0_csum(sb));
 	printf("         Events : %llu\n",
-	       ((unsigned long long)sb->events_hi << 32)
-	       + sb->events_lo);
+	       ((unsigned long long)sb->events_hi << 32) + sb->events_lo);
 	printf("\n");
 	if (sb->level == 5) {
 		c = map_num(r5layout, sb->layout);
@@ -203,16 +216,19 @@ static void examine_super0(struct supertype *st, char *homehost)
 	case 5:
 	case 6:
 	case 10:
-		printf("     Chunk Size : %dK\n", sb->chunk_size/1024);
+		printf("     Chunk Size : %dK\n", sb->chunk_size / 1024);
 		break;
 	case -1:
-		printf("       Rounding : %dK\n", sb->chunk_size/1024);
+		printf("       Rounding : %dK\n", sb->chunk_size / 1024);
 		break;
-	default: break;
+	default:
+		break;
 	}
 	printf("\n");
 	printf("      Number   Major   Minor   RaidDevice State\n");
-	for (d= -1; d<(signed int)(sb->raid_disks+delta_extra + sb->spare_disks); d++) {
+	for (d = -1;
+	     d < (signed int)(sb->raid_disks + delta_extra + sb->spare_disks);
+	     d++) {
 		mdp_disk_t *dp;
 		char *dv;
 		char nb[5];
@@ -220,20 +236,27 @@ static void examine_super0(struct supertype *st, char *homehost)
 		if (d>=0) dp = &sb->disks[d];
 		else dp = &sb->this_disk;
 		snprintf(nb, sizeof(nb), "%4d", d);
-		printf("%4s %5d   %5d    %5d    %5d     ", d < 0 ? "this" :  nb,
+		printf("%4s %5d   %5d    %5d    %5d     ", d < 0 ? "this" : nb,
 		       dp->number, dp->major, dp->minor, dp->raid_disk);
-		wonly = dp->state & (1<<MD_DISK_WRITEMOSTLY);
-		dp->state &= ~(1<<MD_DISK_WRITEMOSTLY);
-		if (dp->state & (1<<MD_DISK_FAULTY)) printf(" faulty");
-		if (dp->state & (1<<MD_DISK_ACTIVE)) printf(" active");
-		if (dp->state & (1<<MD_DISK_SYNC)) printf(" sync");
-		if (dp->state & (1<<MD_DISK_REMOVED)) printf(" removed");
-		if (wonly) printf(" write-mostly");
-		if (dp->state == 0) printf(" spare");
-		if ((dv=map_dev(dp->major, dp->minor, 0)))
+		wonly = dp->state & (1 << MD_DISK_WRITEMOSTLY);
+		dp->state &= ~(1 << MD_DISK_WRITEMOSTLY);
+		if (dp->state & (1 << MD_DISK_FAULTY))
+			printf(" faulty");
+		if (dp->state & (1 << MD_DISK_ACTIVE))
+			printf(" active");
+		if (dp->state & (1 << MD_DISK_SYNC))
+			printf(" sync");
+		if (dp->state & (1 << MD_DISK_REMOVED))
+			printf(" removed");
+		if (wonly)
+			printf(" write-mostly");
+		if (dp->state == 0)
+			printf(" spare");
+		if ((dv = map_dev(dp->major, dp->minor, 0)))
 			printf("   %s", dv);
 		printf("\n");
-		if (d == -1) printf("\n");
+		if (d == -1)
+			printf("\n");
 	}
 }
 

--- a/super0.c
+++ b/super0.c
@@ -693,16 +693,14 @@ static int update_super0(struct supertype *st, struct mdinfo *info,
 }
 
 /*
- * For verion-0 superblock, the homehost is 'stored' in the
- * uuid.  8 bytes for a hash of the host leaving 8 bytes
- * of random material.
- * We use the first 8 bytes (64bits) of the sha1 of the
- * host name
+ * For version-0 superblock, the homehost is 'stored' in the uuid.
+ * 8 bytes for a hash of the host leaving 8 bytes of random material.
+ * We use the first 8 bytes (64bits) of the sha1 of the host name
  */
-
 static int init_super0(struct supertype *st, mdu_array_info_t *info,
-		       unsigned long long size, char *ignored_name, char *homehost,
-		       int *uuid, unsigned long long data_offset)
+		       unsigned long long size, char *ignored_name,
+		       char *homehost, int *uuid,
+		       unsigned long long data_offset)
 {
 	mdp_super_t *sb;
 	int spares;

--- a/super0.c
+++ b/super0.c
@@ -1139,7 +1139,7 @@ static int add_internal_bitmap0(struct supertype *st, int *chunkp,
 		if (chunk < 64*1024*1024)
 			chunk = 64*1024*1024;
 	} else if ((unsigned long long)chunk < min_chunk)
-		return 0; /* chunk size too small */
+		return -EINVAL; /* chunk size too small */
 
 	sb->state |= (1<<MD_SB_BITMAP_PRESENT);
 
@@ -1153,7 +1153,7 @@ static int add_internal_bitmap0(struct supertype *st, int *chunkp,
 	bms->sync_size = __cpu_to_le64(size);
 	bms->write_behind = __cpu_to_le32(write_behind);
 	*chunkp = chunk;
-	return 1;
+	return 0;
 }
 
 static int locate_bitmap0(struct supertype *st, int fd, int node_num)

--- a/super0.c
+++ b/super0.c
@@ -752,16 +752,12 @@ static int init_super0(struct supertype *st, mdu_array_info_t *info,
 		sb->set_uuid2 = uuid[2];
 		sb->set_uuid3 = uuid[3];
 	} else {
-		int rfd = open("/dev/urandom", O_RDONLY);
-		if (rfd < 0 || read(rfd, &sb->set_uuid0, 4) != 4)
-			sb->set_uuid0 = random();
-		if (rfd < 0 || read(rfd, &sb->set_uuid1, 12) != 12) {
-			sb->set_uuid1 = random();
-			sb->set_uuid2 = random();
-			sb->set_uuid3 = random();
-		}
-		if (rfd >= 0)
-			close(rfd);
+		__u32 r[4];
+		random_uuid((__u8 *)r);
+		sb->set_uuid0 = r[0];
+		sb->set_uuid1 = r[1];
+		sb->set_uuid2 = r[2];
+		sb->set_uuid3 = r[3];
 	}
 	if (homehost && !uuid) {
 		char buf[20];

--- a/super1.c
+++ b/super1.c
@@ -2270,7 +2270,7 @@ add_internal_bitmap1(struct supertype *st,
 		}
 		break;
 	default:
-		return 0;
+		return -ENOSPC;
 	}
 
 	room -= bbl_size;
@@ -2280,7 +2280,7 @@ add_internal_bitmap1(struct supertype *st,
 
 	if (room <= 1)
 		/* No room for a bitmap */
-		return 0;
+		return -ENOSPC;
 
 	max_bits = (room * 512 - sizeof(bitmap_super_t)) * 8;
 
@@ -2298,9 +2298,9 @@ add_internal_bitmap1(struct supertype *st,
 		if (chunk < 64*1024*1024)
 			chunk = 64*1024*1024;
 	} else if (chunk < min_chunk)
-		return 0; /* chunk size too small */
+		return -EINVAL; /* chunk size too small */
 	if (chunk == 0) /* rounding problem */
-		return 0;
+		return -EINVAL;
 
 	if (offset == 0) {
 		/* start bitmap on a 4K boundary with enough space for
@@ -2336,7 +2336,7 @@ add_internal_bitmap1(struct supertype *st,
 	}
 
 	*chunkp = chunk;
-	return 1;
+	return 0;
 }
 
 static int locate_bitmap1(struct supertype *st, int fd, int node_num)

--- a/super1.c
+++ b/super1.c
@@ -2394,6 +2394,11 @@ static int write_bitmap1(struct supertype *st, int fd, enum bitmap_update update
 			return -EINVAL;
 		}
 
+		if (bms->version == BITMAP_MAJOR_CLUSTERED && st->nodes <= 1) {
+			pr_err("Warning: cluster-md at least needs two nodes\n");
+			return -EINVAL;
+		}
+
 		/* Each node has an independent bitmap, it is necessary to calculate the
 		 * space is enough or not, first get how many bytes for the total bitmap */
 		bm_space_per_node = calc_bitmap_size(bms, 4096);

--- a/super1.c
+++ b/super1.c
@@ -2389,7 +2389,7 @@ static int write_bitmap1(struct supertype *st, int fd, enum bitmap_update update
 		break;
 	case NodeNumUpdate:
 		/* cluster md only supports superblock 1.2 now */
-		if (st->minor_version != 2) {
+		if (st->minor_version != 2 && bms->version == BITMAP_MAJOR_CLUSTERED) {
 			pr_err("Warning: cluster md only works with superblock 1.2\n");
 			return -EINVAL;
 		}

--- a/super1.c
+++ b/super1.c
@@ -1643,7 +1643,8 @@ static unsigned long choose_bm_space(unsigned long devsize)
 	 * NOTE: result must be multiple of 4K else bad things happen
 	 * on 4K-sector devices.
 	 */
-	if (devsize < 64*2) return 0;
+	if (devsize < 64*2)
+		return 0;
 	if (devsize - 64*2 >= 200*1024*1024*2)
 		return 128*2;
 	if (devsize - 4*2 > 8*1024*1024*2)

--- a/sysfs.c
+++ b/sysfs.c
@@ -394,7 +394,8 @@ unsigned long long get_component_size(int fd)
 	struct stat stb;
 	char fname[50];
 	int n;
-	if (fstat(fd, &stb)) return 0;
+	if (fstat(fd, &stb))
+		return 0;
 	if (major(stb.st_rdev) != (unsigned)get_mdp_major())
 		sprintf(fname, "/sys/block/md%d/md/component_size",
 			(int)minor(stb.st_rdev));

--- a/util.c
+++ b/util.c
@@ -928,7 +928,7 @@ int get_data_disks(int level, int layout, int raid_disks)
 	return data_disks;
 }
 
-int devnm2devid(char *devnm)
+dev_t devnm2devid(char *devnm)
 {
 	/* First look in /sys/block/$DEVNM/dev for %d:%d
 	 * If that fails, try parsing out a number
@@ -1065,7 +1065,7 @@ int dev_open(char *dev, int flags)
 
 int open_dev_flags(char *devnm, int flags)
 {
-	int devid;
+	dev_t devid;
 	char buf[20];
 
 	devid = devnm2devid(devnm);
@@ -1083,7 +1083,7 @@ int open_dev_excl(char *devnm)
 	char buf[20];
 	int i;
 	int flags = O_RDWR;
-	int devid = devnm2devid(devnm);
+	dev_t devid = devnm2devid(devnm);
 	long delay = 1000;
 
 	sprintf(buf, "%d:%d", major(devid), minor(devid));

--- a/util.c
+++ b/util.c
@@ -1039,7 +1039,8 @@ int dev_open(char *dev, int flags)
 	int major;
 	int minor;
 
-	if (!dev) return -1;
+	if (!dev)
+		return -1;
 	flags |= O_DIRECT;
 
 	if (get_maj_min(dev, &major, &minor)) {

--- a/util.c
+++ b/util.c
@@ -1936,6 +1936,27 @@ __u32 random32(void)
 	return rv;
 }
 
+void random_uuid(__u8 *buf)
+{
+	int fd, i, len;
+	__u32 r[4];
+
+	fd = open("/dev/urandom", O_RDONLY);
+	if (fd < 0)
+		goto use_random;
+	len = read(fd, buf, 16);
+	close(fd);
+	if (len != 16)
+		goto use_random;
+
+	return;
+
+use_random:
+	for (i = 0; i < 4; i++)
+		r[i] = random();
+	memcpy(buf, r, 16);
+}
+
 #ifndef MDASSEMBLE
 int flush_metadata_updates(struct supertype *st)
 {


### PR DESCRIPTION
When we added more than 128 md devices, we started getting failures. Looking through the code it seems that the minor dev number was being stored in an int and causing overflow and wrecking havoc on everything. I finally got the mknod in mdadm to correctly make the dev node with minors up to 1048574 as expected in the mdadm code. However, I can only create md devices up to 511. Trying to create an md higher than that has an error where the device can't be read/opened strace reports:
open("/dev/.tmp.md.15341:9:1048574", O_RDWR|O_EXCL|O_DIRECT) = -1 ENXIO (No such device or address)
while Python reports:
IOError: [Errno 6] No such device or address: '/dev/.tmp.md.3279:9:512'

A corresponding node is not created in /sys/block/md* for mds over 511.

I believe that there may be a bug in the kernel code that is now being hit. After looking through the kernel code, I can't seem to find where this might be. Please help me by either pointing me to the source location that this might be a problem or fixing it based on the pull request I've worked on so far. I'm using 4.7.0 currently.

I'm using this for testing:
./mdadm --create /dev/md1048574 --assume-clean --verbose --level=1 --raid-devices=2 /dev/loop0 missing

Yes, we have a real need for more than 128 and 512 md devices.

Thank you.