### PR TITLE
fix gcc-8 format-truncation warning

### DIFF
--- a/super0.c
+++ b/super0.c
@@ -229,7 +229,7 @@ static void examine_super0(struct supertype *st, char *homehost)
 	     d++) {
 		mdp_disk_t *dp;
 		char *dv;
-		char nb[11];
+		char nb[12];
 		int wonly, failfast;
 		if (d>=0) dp = &sb->disks[d];
 		else dp = &sb->this_disk;


### PR DESCRIPTION
While compiling with `-Werror=format-truncation=', it failed
[snip]
|super0.c:236:32: error: 'snprintf' output may be truncated
before the last format character [-Werror=format-truncation=]
|   snprintf(nb, sizeof(nb), "%4d", d);
|                                ^
|super0.c:236:3: note: 'snprintf' output between 5 and 12 bytes
into a destination of size 11
|   snprintf(nb, sizeof(nb), "%4d", d);
[snip]

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>