### PR TITLE
systemd: use unescaped path

### DIFF
--- a/systemd/mdadm-last-resort@.service
+++ b/systemd/mdadm-last-resort@.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Activate md array %I even though degraded
 DefaultDependencies=no
-ConditionPathExists=!/sys/devices/virtual/block/%i/md/sync_action
+ConditionPathExists=!/sys/devices/virtual/block/%I/md/sync_action
 
 [Service]
 Type=oneshot
-ExecStart=BINDIR/mdadm --run /dev/%i
+ExecStart=BINDIR/mdadm --run /dev/%I


### PR DESCRIPTION
The last resort service uses %i which the escaped version of the path
like dev-md-boot for /dev/md/boot. The service fails since mdadm expects
the unescaped path, which is represented by %I. Use that.