### PR TITLE
mdadm: fix gcc8 maybe-uninitialized/format-overflow warning

### DIFF
--- a/Incremental.c
+++ b/Incremental.c
@@ -1499,7 +1499,7 @@ static int Incremental_container(struct supertype *st, char *devname,
 		return 0;
 	}
 	for (ra = list ; ra ; ra = ra->next) {
-		int mdfd;
+		int mdfd = 0;
 		char chosen_name[1024];
 		struct map_ent *mp;
 		struct mddev_ident *match = NULL;

--- a/super-intel.c
+++ b/super-intel.c
@@ -9585,9 +9585,9 @@ static int apply_takeover_update(struct imsm_update_takeover *u,
 			du->major = 0;
 			du->index = (i * 2) + 1;
 			sprintf((char *)du->disk.serial,
-				" MISSING_%d", du->index);
+				" MISSING_%hu", du->index);
 			sprintf((char *)du->serial,
-				"MISSING_%d", du->index);
+				"MISSING_%hu", du->index);
 			du->next = super->missing;
 			super->missing = du;
 		}


### PR DESCRIPTION
while compiled with -Werror=maybe-uninitialized/-Werror=format-overflow=,
it failed

[snip]
| Incremental.c: In function 'Incremental_container':
| Incremental.c:1593:3: error: 'mdfd' may be used uninitialized in this function [-Werror=maybe-uninitialized]
|    close(mdfd);
|    ^~~~~~~~~~~

[snip]
 super-intel.c: In function 'apply_takeover_update':
| super-intel.c:9615:15: error: '%d' directive writing between 1 and 11 bytes into a region of size 7 [-Werror=format-overflow=]
|      " MISSING_%d", du->index);
|                ^~

Signed-off-by: Changqing Li <changqing.li@windriver.com>